### PR TITLE
Clarify reps declaration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ Now.
 ## How do I get it?
 Add
 ```elixir
-[{:csv, "~> 1.1.0"}]
+{:csv, "~> 1.1.0"}
 ```
-to your deps in `mix.exs`
+to your deps in `mix.exs` like so:
 
+```elixir
+defp deps do
+  [
+    {:csv, "~> 1.1.0"}
+  ]
+end
+```
 ## Great! How do I use it right now?
 
 Do this to decode:


### PR DESCRIPTION
This is a really, really small change but I thought it made sense. The terminology in the original `README.md` (line 19) made it look as if to get it you add `[{:csv, "~> 1.1.0"}]` to the function `deps` in `mix.exs`, but as you know you just add the tuple of the symbol + string, not the tuple in a list.

Thanks for the great work! 
